### PR TITLE
Improve performance of fastConcatMap

### DIFF
--- a/src/NoForbiddenWords.elm
+++ b/src/NoForbiddenWords.elm
@@ -326,4 +326,9 @@ fastConcat =
 
 fastConcatMap : (a -> List b) -> List a -> List b
 fastConcatMap fn =
-    List.foldr (fn >> (++)) []
+    let
+        helper : a -> List b -> List b
+        helper item acc =
+            acc ++ fn item
+    in
+    List.foldr helper []

--- a/src/NoForbiddenWords.elm
+++ b/src/NoForbiddenWords.elm
@@ -329,6 +329,6 @@ fastConcatMap fn =
     let
         helper : a -> List b -> List b
         helper item acc =
-            acc ++ fn item
+            fn item ++ acc
     in
     List.foldr helper []


### PR DESCRIPTION
@jfmengels discovered that a function/lambda is better than using `>>`: <https://github.com/jfmengels/elm-benchmarks>